### PR TITLE
Implement ApplicationPaths to customise the paths used by the application

### DIFF
--- a/src/Core/Application.php
+++ b/src/Core/Application.php
@@ -17,9 +17,10 @@ class Application implements ApplicationInterface
     /** @var ModuleInterface[] */
     private array $modules = [];
     private bool $booted = false;
+    private ApplicationPathsInterface $path;
 
     public function __construct(
-        private readonly string $basePath,
+        string|ApplicationPathsInterface $path,
         private readonly ContainerInterface $container = new Container(),
         private readonly array $bootstrappers = [
             ConfigBootstrapper::class,
@@ -27,39 +28,38 @@ class Application implements ApplicationInterface
             ModuleBootstrapper::class,
         ],
     ) {
+        $this->path = \is_string($path) ? new ApplicationPaths($path) : $path;
         $this->registerBaseBindings();
     }
 
     public function getBasePath(?string $path = null): string
     {
-        return empty($path)
-            ? $this->basePath
-            : $this->basePath . DIRECTORY_SEPARATOR . \ltrim($path, '/\\');
+        return $this->path->getBasePath($path);
     }
 
     public function getConfigPath(): string
     {
-        return $this->getBasePath('etc/config');
+        return $this->path->getConfigPath();
     }
 
     public function getRoutesPath(): string
     {
-        return $this->getBasePath('etc/routes.php');
+        return $this->path->getRoutesPath();
     }
 
     public function getCachedConfigPath(): string
     {
-        return $this->getBasePath('var/cache/cached-config.php');
+        return $this->path->getCachedConfigPath();
     }
 
     public function getCachedRoutesPath(): string
     {
-        return $this->getBasePath('var/cache/cached-routes.php');
+        return $this->path->getCachedRoutesPath();
     }
 
     public function getDocumentRoot(): string
     {
-        return $this->getBasePath('public');
+        return $this->path->getDocumentRoot();
     }
 
     public function bind(string $key, string|\Closure $implementation, bool $isShared = false): void

--- a/src/Core/ApplicationPaths.php
+++ b/src/Core/ApplicationPaths.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Strike\Framework\Core;
+
+class ApplicationPaths implements ApplicationPathsInterface
+{
+    public function __construct(private readonly string $basePath)
+    {
+    }
+
+    public function getBasePath(?string $path = null): string
+    {
+        return empty($path)
+            ? $this->basePath
+            : \rtrim($this->basePath, '/\\'). DIRECTORY_SEPARATOR . \ltrim($path, '/\\');
+    }
+
+    public function getConfigPath(): string
+    {
+        return $this->getBasePath('etc/config');
+    }
+
+    public function getRoutesPath(): string
+    {
+        return $this->getBasePath('etc/routes.php');
+    }
+
+    public function getCachedConfigPath(): string
+    {
+        return $this->getBasePath('var/cache/cached-config.php');
+    }
+
+    public function getCachedRoutesPath(): string
+    {
+        return $this->getBasePath('var/cache/cached-routes.php');
+    }
+
+    public function getDocumentRoot(): string
+    {
+        return $this->getBasePath('public');
+    }
+}

--- a/src/Core/ApplicationPathsInterface.php
+++ b/src/Core/ApplicationPathsInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Strike\Framework\Core;
+
+interface ApplicationPathsInterface
+{
+    public function getBasePath(?string $path = null): string;
+
+    public function getConfigPath(): string;
+
+    public function getRoutesPath(): string;
+
+    public function getCachedConfigPath(): string;
+
+    public function getCachedRoutesPath(): string;
+
+    public function getDocumentRoot(): string;
+}

--- a/tests/Unit/Core/ApplicationPathsTest.php
+++ b/tests/Unit/Core/ApplicationPathsTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Strike\Framework\Unit\Core;
+
+use Strike\Framework\Core\ApplicationPaths;
+use PHPUnit\Framework\TestCase;
+
+class ApplicationPathsTest extends TestCase
+{
+    public function testGetBasePathWillTrimDirectorySeparators(): void
+    {
+        $appPaths = new ApplicationPaths('/');
+
+        $testPath = $appPaths->getBasePath('/test');
+
+        self::assertEquals('/test', $testPath);
+    }
+
+    public function testGetBasePathWithoutArgumentReturnsTheBasePath(): void
+    {
+        $appPaths = new ApplicationPaths('/');
+
+        $basePath = $appPaths->getBasePath();
+
+        self::assertEquals('/', $basePath);
+    }
+
+    public function testGetConfigPath()
+    {
+        $appPaths = new ApplicationPaths('/');
+
+        $configPath = $appPaths->getConfigPath();
+
+        self::assertEquals('/etc/config', $configPath);
+    }
+
+    public function testGetCachedConfigPath()
+    {
+        $appPaths = new ApplicationPaths('/');
+
+        $cachedConfigPath = $appPaths->getCachedConfigPath();
+
+        self::assertEquals('/var/cache/cached-config.php', $cachedConfigPath);
+    }
+
+    public function testGetCachedRoutesPath()
+    {
+        $appPaths = new ApplicationPaths('/');
+
+        $cachedRoutesPath = $appPaths->getCachedRoutesPath();
+
+        self::assertEquals('/var/cache/cached-routes.php', $cachedRoutesPath);
+    }
+
+    public function testGetRoutesPath()
+    {
+        $appPaths = new ApplicationPaths('/');
+
+        $routesPath = $appPaths->getRoutesPath();
+
+        self::assertEquals('/etc/routes.php', $routesPath);
+    }
+
+    public function testGetDocumentRoot()
+    {
+        $appPaths = new ApplicationPaths('/');
+
+        $documentRoot = $appPaths->getDocumentRoot();
+
+        self::assertEquals('/public', $documentRoot);
+    }
+}


### PR DESCRIPTION
Instead of extending the application class to customise the paths, we introduce an `ApplicationPathsInterface` with a default implementation.

It can be used instead of a string as first argument of the constructor of the `Application` class.
